### PR TITLE
style: Apply Design Revision on Notice Page

### DIFF
--- a/src/assets/icons/arrow-left.svg
+++ b/src/assets/icons/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M38 24H10M10 24L24 38M10 24L24 10" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/icons/BtnBack.tsx
+++ b/src/components/icons/BtnBack.tsx
@@ -1,0 +1,17 @@
+import type { ComponentProps } from "react";
+import Arrow from '@icons/arrow-left.svg?react';
+import { css } from "@emotion/react";
+import { colors } from "@/styles/styles";
+
+const BtnBack = ({...props}: ComponentProps<'button'>) => {
+    return <button css={css`
+        color: ${colors.primary};
+        line-height: 0;
+        width: 4.8rem;
+        height: 4.8rem;
+    `} aria-label='뒤로가기' {...props}>
+        <Arrow/>
+    </button>
+}
+
+export default BtnBack;

--- a/src/pages/notice/Notice.tsx
+++ b/src/pages/notice/Notice.tsx
@@ -5,23 +5,21 @@ import { css } from '@emotion/react';
 import { useState } from 'react';
 import RingBinder from '@images/ring-binder-vt.svg?react';
 import type { Post } from '@/types/schema';
+import BtnBack from '@/components/icons/BtnBack';
 
 const containerCss = css`
   height: 100%;
-  overflow-y: hidden;
+  overflow-y: scroll;
   background-color: ${colors.primary10};
   color: ${colors.primary};
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 54px;
 
   header {
     width: 100%;
-    position: fixed;
     background-color: ${colors.primary10};
-    z-index: 10;
     border-bottom: dashed 5px ${colors.primary};
     * {
       margin: 54px auto 0 26px;
@@ -33,9 +31,7 @@ const containerCss = css`
   }
 
   section {
-    margin-top: calc(220px + 5rem);
     width: 100%;
-    overflow-y: scroll;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -45,11 +41,10 @@ const containerCss = css`
 
   #modal {
     width: 100%;
-    height: calc(100vh - 140px);
-    top: 140px;
+    height: calc(100vh - 120px);
+    top: 120px;
     position: absolute;
-    z-index: 40;
-    background-color: ${colors.primary10};
+    z-index: 20;
     color: ${colors.white};
     padding: 24px;
     padding-bottom: 0;
@@ -64,15 +59,21 @@ const containerCss = css`
     }
     #ringbinder {
       position: fixed;
-      top: 200px;
+      top: 180px;
       left: 12px;
       color: ${colors.primary20};
       ${shadows.dropBottom};
     }
     #inset {
-      background-color: transparent;
+      background-color: ${colors.primary10};
       inset: 0;
       position: fixed;
+    }
+    button {
+      position: fixed;
+      top: 5.2rem;
+      z-index: 20;
+      margin: 6px;
     }
   }
 `;
@@ -94,10 +95,12 @@ const Posts: Post[] = [
 const Notice = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [currentPost, setCurrentPost] = useState<Post>();
-  const handleBannerClick = (i: number) => {
+  const [visitedPostIDs, setVisitedPostIDs] = useState<number[]>([]);
+  const handleBannerClick = (id: number) => {
     // console.log(Posts.at(i)?.content);
-    setCurrentPost(Posts[i]);
+    setCurrentPost(Posts.find((e) => e.id === id));
     setModalOpen(true);
+    setVisitedPostIDs([...visitedPostIDs, id]);
   };
 
   return (
@@ -109,21 +112,21 @@ const Notice = () => {
       <section>
         <Banner text='총학생회 카카오톡 채널' />
         <Star size='md' color='primary' />
-        <Banner text='공지 1' variant='primary' />
         {Posts.map((e, i) => (
           <Banner
             text={e.title}
             onClick={() => {
-              handleBannerClick(i);
+              handleBannerClick(e.id);
             }}
-            variant='secondary'
+            variant={visitedPostIDs.includes(e.id) ? 'secondary' : 'primary'}
             key={i}
           />
         ))}
       </section>
       {modalOpen && (
         <div id='modal'>
-          <div id='inset' onClick={() => setModalOpen(false)} />
+          <BtnBack onClick={() => setModalOpen(false)} />
+          <div id='inset' />
           <div id='notice-detail'>
             <p>{currentPost?.title}</p>
             <p>{currentPost?.content}</p>


### PR DESCRIPTION
# 구현 내용
* 공지 디자인 수정사항 반영 (overflow 영역 변경 등)
* `BtnBack` 컴포넌트 추가
* visited Post의 variant 변경되도록 구현
<img height="422" alt="notice-rev1" src="https://github.com/user-attachments/assets/c7717317-c82e-4a20-b7b4-d9cc3e5b7b13"/>
<img height="422"alt="notice-rev2" src="https://github.com/user-attachments/assets/b4fba52d-3e25-49ee-931c-4a400015165c"/>


## Todo:

* 이미지 첨부된 포스트는 디자인되는대로 반영