### PR TITLE
feat: Connect timetable Api and apply Dayjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@types/node": "^24.0.12",
         "axios": "^1.11.0",
+        "dayjs": "^1.11.18",
         "embla-carousel-react": "^8.6.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2715,6 +2716,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@types/node": "^24.0.12",
     "axios": "^1.11.0",
+    "dayjs": "^1.11.18",
     "embla-carousel-react": "^8.6.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,7 @@
 import axios, { type AxiosResponse } from 'axios';
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
 
 const apiUrl = `${import.meta.env.VITE_API}`;
 
@@ -27,7 +29,14 @@ const parseDates = (data: any): any => {
   for (const k in data) {
     if (Object.prototype.hasOwnProperty.call(data, k)) {
       const v = data[k];
-      if (typeof v === 'string' && dayjs(v).isValid()) {
+      if (
+        typeof v === 'string' &&
+        dayjs(
+          v,
+          ['YYYY-MM-DDTHH:mm:ss', 'YYYY-MM-DDTHH:mm:ss.SSS'],
+          true
+        ).isValid()
+      ) {
         newData[k] = dayjs(v); // parse string to date
       } else if (typeof v === 'object') {
         newData[k] = parseDates(v); // recursion

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import type { Booth, Post } from '@/types/schema';
+import type { Booth, Post, Timeslot } from '@/types/schema';
 import axiosInstance from './axios';
 import { API_ENDPOINTS } from './endpoints';
 import type { Dispatch, SetStateAction } from 'react';
@@ -13,4 +13,9 @@ export const getBooths = async (
 ) => {
   const response = await axiosInstance.get<Booth[]>(API_ENDPOINTS.GET_BOOTHS);
   setBooths(response.data);
+};
+
+export const getTimeSlots = async (setTimeslots: Dispatch<SetStateAction<Timeslot[]>>) => {
+  const { data } = await axiosInstance.get<Timeslot[]>(API_ENDPOINTS.GET_TIMETABLE);
+  setTimeslots(data);
 };

--- a/src/api/mockData.ts
+++ b/src/api/mockData.ts
@@ -5,13 +5,16 @@ export const days = [
   dayjs('2025-09-11'),
   dayjs('2025-09-12'),
   // dayjs('2025-09-13'),
-]
+];
 
 export const areaData: Area = {
   id: 1,
   name: 'area1',
   description: 'desc',
-  hour: { open: '2025-08-20T09:00:00', close: '2025-08-20T18:00:00' },
+  hour: {
+    open: dayjs('2025-08-20T09:00:00'),
+    close: dayjs('2025-08-20T18:00:00'),
+  },
   points: [],
 };
 export const categoriesData: Category[] = [
@@ -27,7 +30,10 @@ export const boothsData: Booth[] = [
     name: '부스명 01',
     description: '부스에 관한 설명 예시',
     point: { x: 375, y: 750 },
-    hour: { open: '2025-08-20T09:00:00', close: '2025-08-20T18:00:00' },
+    hour: {
+      open: dayjs('2025-08-20T09:00:00'),
+      close: dayjs('2025-08-20T18:00:00'),
+    },
   },
   {
     dtype: 'store',
@@ -37,8 +43,14 @@ export const boothsData: Booth[] = [
     name: '부스명 03',
     description: 'Lorem ipsum dolor, sit amet consectetur adipisicing elit.',
     point: { x: 375, y: 250 },
-    hour: { open: '2025-08-20T09:00:00', close: '2025-08-20T18:00:00' },
-    images: ['https://avatars.githubusercontent.com/u/220365751?s=200&v=4','/img-02.jpg'],
+    hour: {
+      open: dayjs('2025-08-20T09:00:00'),
+      close: dayjs('2025-08-20T18:00:00'),
+    },
+    images: [
+      'https://avatars.githubusercontent.com/u/220365751?s=200&v=4',
+      '/img-02.jpg',
+    ],
   },
 ];
 
@@ -76,21 +88,21 @@ export const timeslotData: Timeslot[] = [
   {
     id: 0,
     name: 'name',
-    startTime: '2025-05-07T13:00:00',
-    endTime: '2025-05-07T15:00:00',
+    startTime: dayjs('2025-05-07T13:00:00'),
+    endTime: dayjs('2025-05-07T15:00:00'),
   },
   {
     id: 1,
     name: 'name',
-    startTime: '2025-05-07T16:00:00',
-    endTime: '2025-05-07T20:00:00',
+    startTime: dayjs('2025-05-07T16:00:00'),
+    endTime: dayjs('2025-05-07T20:00:00'),
     href: 'https://instagram.com/',
   },
   {
     id: 2,
     name: 'name',
-    startTime: '2025-05-07T10:30:00',
-    endTime: '2025-05-07T11:45:00',
+    startTime: dayjs('2025-05-07T10:30:00'),
+    endTime: dayjs('2025-05-07T11:45:00'),
     href: 'https://instagram.com/',
   },
 ];

--- a/src/api/mockData.ts
+++ b/src/api/mockData.ts
@@ -1,4 +1,11 @@
 import type { Area, Booth, Category, Post, Timeslot } from '@/types/schema';
+import dayjs from 'dayjs';
+
+export const days = [
+  dayjs('2025-09-11'),
+  dayjs('2025-09-12'),
+  // dayjs('2025-09-13'),
+]
 
 export const areaData: Area = {
   id: 1,

--- a/src/api/mockData.ts
+++ b/src/api/mockData.ts
@@ -1,4 +1,4 @@
-import type { Area, Booth, Category, Post } from '@/types/schema';
+import type { Area, Booth, Category, Post, Timeslot } from '@/types/schema';
 
 export const areaData: Area = {
   id: 1,
@@ -43,8 +43,47 @@ export const postsData: Post[] = [
   },
   {
     id: 2,
-    title: 'title2',
-    content:
-      'content2 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!',
+    title: '2025 ESKARA: 초록의 파도',
+    content: `불어오는 바람을 따라
+더욱 거세게 일렁일,
+
+2025 ESKARA: 초록의 파도
+
+| 9. 11. - 9. 12. 
+성균관대학교 자연과학캠퍼스`,
+    images: [
+      "https://flzedqolwsvpundopfcv.supabase.co/storage/v1/object/public/images/post/1/538384101_17897415579279504_1198110012817654601_n.jpg",
+      'https://flzedqolwsvpundopfcv.supabase.co/storage/v1/object/public/images/post/1/539195561_17897415570279504_8517221295134760683_n.jpg',
+      'https://flzedqolwsvpundopfcv.supabase.co/storage/v1/object/public/images/post/1/540624198_17897415558279504_3597118504383467209_n.jpg',
+    ]
+  },
+  {
+    id: 3,
+    title: 'notice w/ image 2',
+    content: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero saepe velit nesciunt fugit et nemo eius perspiciatis, consequuntur, temporibus exercitationem similique minima ab rem!Lorem ipsum dolor sit amet, consectetur adipisicing elit. Harum error consequatur qui nostrum voluptatem vero ',
+    images: ['/img-01.jpg','/img-01.jpg','/img-02.jpg']
+  },
+];
+
+export const timeslotData: Timeslot[] = [
+  {
+    id: 0,
+    name: 'name',
+    startTime: '2025-05-07T13:00:00',
+    endTime: '2025-05-07T15:00:00',
+  },
+  {
+    id: 1,
+    name: 'name',
+    startTime: '2025-05-07T16:00:00',
+    endTime: '2025-05-07T20:00:00',
+    href: 'https://instagram.com/',
+  },
+  {
+    id: 2,
+    name: 'name',
+    startTime: '2025-05-07T10:30:00',
+    endTime: '2025-05-07T11:45:00',
+    href: 'https://instagram.com/',
   },
 ];

--- a/src/components/Selector/DateSelector.tsx
+++ b/src/components/Selector/DateSelector.tsx
@@ -61,7 +61,7 @@ const containerCss = css`
 `;
 
 export type valueType = 'left' | 'center' | 'right';
-type LabelsType = {
+export type LabelsType = {
   left: string;
   center?: string;
   right: string;
@@ -109,7 +109,9 @@ const DateSelector = ({ labels, onChange }: TripleToggleSwitchProps) => {
           }}
         ></div>
 
-        {labelKeys.map((key) => (
+        {labelKeys
+          .filter((key) => labels[key])
+          .map((key) => (
           <label
             key={key}
             ref={(el) => {

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { getPosts } from '@/api';
 import type { Post } from '@/types/schema';
 import { useNavigate } from 'react-router-dom';
+import { days } from '@/api/mockData';
 
 const containerCss = css`
   min-height: 100%;
@@ -23,7 +24,7 @@ const containerCss = css`
 `;
 
 // const imageList = ['/img-01.jpg', '/img-02.jpg', '/img-02.jpg'];
-const dateList = ['09.11.', '12'];
+const dateList = days;
 
 const Home = () => {
   const [posts, setPosts] = useState<Post[]>([]);

--- a/src/pages/home/HomeContents.tsx
+++ b/src/pages/home/HomeContents.tsx
@@ -2,6 +2,7 @@ import { colors, fonts } from '@/styles/styles';
 import { css } from '@emotion/react';
 import Arrow0 from '@images/arrow-bold-down.svg?react';
 import Arrow1 from '@images/arrow-second.svg?react';
+import type dayjs from 'dayjs';
 
 const contentsCss = css`
   width: 101%;
@@ -28,11 +29,11 @@ const contentsCss = css`
   .arrow {
     height: 0;
     position: relative;
-    right: 20px;
-    top: 30px;
+    right: 90px;
+    top: 50px;
   }
   .date-wrapper:nth-of-type(2n) .arrow{
-    left: 80px;
+    left: 100px;
     svg{
       -webkit-transform: scaleX(-1);
       transform: scaleX(-1);
@@ -43,7 +44,7 @@ const contentsCss = css`
   }
 `;
 interface HomeContentsProps {
-  dateList: string[];
+  dateList: dayjs.Dayjs[];
 }
 const HomeContents = ({ dateList }: HomeContentsProps) => {
   return (
@@ -63,7 +64,7 @@ const HomeContents = ({ dateList }: HomeContentsProps) => {
           return (
             <div className='date-wrapper' key={i}>
               <div className='dayorder'>day{i + 1}</div>
-              <div className='date'>{date}</div>
+              <div className='date'>{date.format((i==0) ? 'MM.DD' : 'DD')}</div>
               <div className="arrow"><Arrow1/></div>
             </div>
           );

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -15,7 +15,7 @@ import BoothInfoModal from './BoothInfoModal';
 import DateSelector, { type LabelsType } from '@/components/Selector/DateSelector';
 import DayNightSelector from '@/components/Selector/DayNightSelector';
 import { getBooths } from '@/api';
-import { boothsData, days } from '@/api/mockData';
+import { days } from '@/api/mockData';
 
 const mapImgSize = { h: '1000px', w: '750px' };
 // const mapImgSize = {h: '2000px', w: '1500px'}
@@ -96,7 +96,7 @@ const MapPage = () => {
   };
 
   useEffect(() => {
-    setBooths(boothsData); // Mockup data
+    // setBooths(boothsData); // Mockup data
     getBooths(setBooths);
   }, []);
 

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -12,10 +12,10 @@ import {
 import type { Booth } from '@/types/schema';
 import Card from '@/components/Card';
 import BoothInfoModal from './BoothInfoModal';
-import DateSelector from '@/components/Selector/DateSelector';
+import DateSelector, { type LabelsType } from '@/components/Selector/DateSelector';
 import DayNightSelector from '@/components/Selector/DayNightSelector';
 import { getBooths } from '@/api';
-import { boothsData } from '@/api/mockData';
+import { boothsData, days } from '@/api/mockData';
 
 const mapImgSize = { h: '1000px', w: '750px' };
 // const mapImgSize = {h: '2000px', w: '1500px'}
@@ -51,10 +51,10 @@ const containerCss = css`
 `;
 
 const mapImageSrc = ['/img-01.jpg', '/img-02.jpg'];
-const dateLabels = {
-  left: '5/7',
-  center: '5/8',
-  right: '5/9',
+const dateLabels: LabelsType = {
+  left: days[0].format('M/D'),
+  right: days[1].format('M/D'),
+  center: days.at(2)?.format('M/D'),
 };
 
 const secondMapScale = 1.9;

--- a/src/pages/timetable/Timetable.tsx
+++ b/src/pages/timetable/Timetable.tsx
@@ -7,7 +7,7 @@ import DateSelector, {
 } from '@/components/Selector/DateSelector';
 import TimetableTable from './TimetableTable';
 import { Link } from 'react-router-dom';
-import { days, timeslotData } from '@/api/mockData';
+import { days } from '@/api/mockData';
 import type { Timeslot } from '@/types/schema';
 import { getTimeSlots } from '@/api';
 import dayjs from 'dayjs';

--- a/src/pages/timetable/Timetable.tsx
+++ b/src/pages/timetable/Timetable.tsx
@@ -105,8 +105,8 @@ const Timetable = () => {
           rangeEndHour={hourRange.end}
         >
           {timeslots.map((timeslot, i) => {
-            const startTime = dayjs(timeslot.startTime);
-            const endTime = dayjs(timeslot.endTime);
+            const startTime = timeslot.startTime;
+            const endTime = timeslot.endTime;
             const top =
               Math.floor(
                 dayjs

--- a/src/pages/timetable/Timetable.tsx
+++ b/src/pages/timetable/Timetable.tsx
@@ -1,12 +1,14 @@
 import { colors, fonts } from '@/styles/styles';
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DateSelector, {
   type valueType,
 } from '@/components/Selector/DateSelector';
 import TimetableTable from './TimetableTable';
 import { Link } from 'react-router-dom';
-import { timeslotData } from '@/api/mockData';
+// import { timeslotData } from '@/api/mockData';
+import type { Timeslot } from '@/types/schema';
+import { getTimeSlots } from '@/api';
 
 const containerCss = css`
   height: 100%;
@@ -87,6 +89,12 @@ const Timetable = () => {
     console.log(value);
     setCurrentDateLabel(dateLabels[value]);
   };
+  const [timeslots, setTimeslots] = useState<Timeslot[]>([])
+
+  useEffect(() => {
+      // setTimeslots(timeslotData); // Mockup data
+      getTimeSlots(setTimeslots);
+    }, []);
   return (
     <div css={containerCss}>
       <header>
@@ -104,7 +112,7 @@ const Timetable = () => {
           rangeStartHour={hourRange.start}
           rangeEndHour={hourRange.end}
         >
-          {timeslotData.map((timeslot, i) => {
+          {timeslots.map((timeslot, i) => {
             const startTime = new Date(timeslot.startTime);
             const endTime = new Date(timeslot.endTime);
             const top =

--- a/src/pages/timetable/Timetable.tsx
+++ b/src/pages/timetable/Timetable.tsx
@@ -1,12 +1,12 @@
 import { colors, fonts } from '@/styles/styles';
 import { css } from '@emotion/react';
 import { useState } from 'react';
-import type { Timeslot } from '@/types/schema';
 import DateSelector, {
   type valueType,
 } from '@/components/Selector/DateSelector';
 import TimetableTable from './TimetableTable';
 import { Link } from 'react-router-dom';
+import { timeslotData } from '@/api/mockData';
 
 const containerCss = css`
   height: 100%;
@@ -58,33 +58,34 @@ const itemCss = css`
   }
 `;
 
-const Timeslots: Timeslot[] = [
-  {
-    id: 0,
-    name: 'name',
-    startTime: '2025-05-07T13:00:00',
-    endTime: '2025-05-07T15:00:00',
-  },
-  {
-    id: 1,
-    name: 'name',
-    startTime: '2025-05-07T16:00:00',
-    endTime: '2025-05-07T20:00:00',
-    href: 'https://instagram.com/',
-  },
-];
+
 const dateLabels = {
-  left: '5/7',
-  center: '5/8',
-  right: '12/25',
+  left: '9/11',
+  center: '9/11',
+  right: '9/12',
 };
 const hourRange = { start: 9, end: 21 }; // TODO: 응답 데이터 최대 최소 시각 동적으로 구하기
 
+/**
+ * @returns 0 | 0.5 | -0.5
+ */
+const getHalfHours = (date: Date, secondDate?: Date): number => {
+  if (secondDate) {
+    return getHalfHours(date) - getHalfHours(secondDate);
+  } else {
+    return date.getMinutes() < 30 ? 0 : 0.5;
+  }
+};
+const gethhmm = (date: Date): string => {
+  // return `${date.getHours().toString().padStart(2, '0')}:${getHalfHours(date)===0 ? '00':'30'}`
+  return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`
+}
+
 const Timetable = () => {
-  const [currentDateValue, setCurrentDateValue] = useState<valueType>('left');
+  const [currentDateLabel, setCurrentDateLabel] = useState<string>('9/11');
   const onDateChange = (value: valueType) => {
     console.log(value);
-    setCurrentDateValue(value);
+    setCurrentDateLabel(dateLabels[value]);
   };
   return (
     <div css={containerCss}>
@@ -92,7 +93,7 @@ const Timetable = () => {
         <h1>Time Line</h1>
         <DateSelector labels={dateLabels} onChange={onDateChange} />
         <h2>
-          {dateLabels[currentDateValue]
+          {currentDateLabel
             .split('/')
             .map((e) => e.padStart(2, '0'))
             .join('.')}
@@ -103,24 +104,29 @@ const Timetable = () => {
           rangeStartHour={hourRange.start}
           rangeEndHour={hourRange.end}
         >
-          {Timeslots.map((timeslot, i) => {
+          {timeslotData.map((timeslot, i) => {
             const startTime = new Date(timeslot.startTime);
             const endTime = new Date(timeslot.endTime);
-            const top = startTime.getHours() - hourRange.start;
-            const duration = endTime.getHours() - startTime.getHours();
+            const top =
+              startTime.getHours() - hourRange.start + getHalfHours(startTime);
+            const duration =
+              endTime.getHours() -
+              startTime.getHours() +
+              getHalfHours(endTime, startTime);
             return (
               <Link
                 css={itemCss}
                 style={{
                   top: `${top * 44 - 2}px`,
                   height: `${duration * 44 + 2}px`,
+                  left: i%2===0 ? '0' : '50%',
                 }}
                 key={i}
                 to={timeslot.href ?? ''}
               >
                 {timeslot.name}
                 <p>
-                  {startTime.getHours()}:00~{endTime.getHours()}:00
+                  {gethhmm(startTime)}~{gethhmm(endTime)}
                 </p>
               </Link>
             );

--- a/src/pages/timetable/TimetableTable.tsx
+++ b/src/pages/timetable/TimetableTable.tsx
@@ -27,6 +27,11 @@ const tableCss = css`
     &:last-child {
       border-bottom: none;
     }
+    .inner-line {
+      border-bottom: 2px dotted ${colors.primary20};
+      flex-grow: 1;
+      margin-bottom: calc(1.2rem + 8px);  // calc((2.4rem + 18px - 2px) / 2);
+    }
   }
   .item-wrapper {
     position: absolute;
@@ -56,6 +61,7 @@ const TimetableTable = ({
       {hourList.map((e, i) => (
         <div className='hour-line' key={i}>
           <div>{e}</div>
+          <div className="inner-line"></div>
         </div>
       ))}
       <div className="item-wrapper">{children}</div>

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,12 +1,14 @@
+import type dayjs from "dayjs";
+
 interface BaseEntity {
   id: number;
-  createdAt?: string;
-  modifiedAt?: string;
+  createdAt?: dayjs.Dayjs;
+  modifiedAt?: dayjs.Dayjs;
 }
 
 export interface Hour {
-  open: string;
-  close: string;
+  open: dayjs.Dayjs;
+  close: dayjs.Dayjs;
 }
 
 export interface Point {
@@ -65,16 +67,16 @@ export interface Gate extends Booth {
   type: 'ENTRY' | 'EXIT' | 'ALL';
 }
 export interface Stop extends Booth {
-  times: string[];
+  times: dayjs.Dayjs[];
 }
 export interface Store extends Booth {
   menus: Menu[];
 }
 
-export interface Timeslot {
+export interface Timeslot extends BaseEntity {
   id: number;
   name: string;
-  startTime: string;
-  endTime: string;
+  startTime: dayjs.Dayjs;
+  endTime: dayjs.Dayjs;
   href?: string;
 }


### PR DESCRIPTION
# 구현 내용
* 타임테이블 API 연결
* 타임테이블 한칸을 30분 단위로 쪼갬
  * 시간이 애매하게 끊어지는 경우도 테이블 위치는 모두 30분 단위로 맞춰짐
* 각종 시간 데이터 렌더 시 day.js로 처리 및 포맷팅
* axios 인터셉터에서 Dayjs 타입으로 파싱

<img height="422" alt="timetable-rev1" src="https://github.com/user-attachments/assets/e7402b13-301f-46d9-9a56-201c22be30ee" />

## 알려진 문제:

* createdAt은 dayjs가 핸들링하지 못하는 microsecond 단위를 넘겨줌.
